### PR TITLE
Update to FSharpLint.Core 0.0.4

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -14,7 +14,7 @@ NUGET
       FSharp.Compiler.Service (>= 0.0.87)
       FSharpVSPowerTools.Core (1.8.0)
     FSharp.ViewModule.Core (0.9.9.1)
-    FSharpLint.Core (0.0.3)
+    FSharpLint.Core (0.0.4)
       FSharp.Compiler.Service (>= 0.0.89)
     FSharpVSPowerTools.Core (1.8.0)
       FSharp.Compiler.Service (>= 0.0.87)

--- a/src/FSharpVSPowerTools.Logic/LintTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/LintTagger.fs
@@ -29,16 +29,16 @@ type LintTagger(textDocument: ITextDocument,
             let! doc = dte.GetCurrentDocument(textDocument.FilePath)
             let! project = projectFactory.CreateForDocument buffer doc
             let source = buffer.CurrentSnapshot.GetText()
-            let! checkResults = vsLanguageService.ParseAndCheckFileInProject (doc.FullName, source, project) |> liftAsync
-            let! ast = checkResults.GetUntypedAst()
+            let! parseFileResults = vsLanguageService.ParseFileInProject (doc.FullName, source, project) |> liftAsync
+            let! ast = parseFileResults.ParseTree
             let res = 
-                Lint.lintParsedFile 
+                Lint.lintParsedFile
                     { FinishEarly = None
-                      Configuration = None //Configuration.defaultConfiguration
+                      Configuration = None
                       ReceivedWarning = None }
                     { Ast = ast
                       Source = source
-                      TypeCheckResults = checkResults.GetCheckResults() }
+                      TypeCheckResults = None }
                     doc.FullName
 
             return


### PR DESCRIPTION
Use untyped ASTs only to improve responsiveness.